### PR TITLE
Add woff2 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = postcss.plugin('postcss-fontpath', function (opts) {
             ieSrc = 'url("' + fontPath + '.eot")',
             formats = [
               { type: 'embedded-opentype', ext: '.eot?#iefix' },
+              { type: 'woff2', ext: '.woff2' },
               { type: 'woff', ext: '.woff' },
               { type: 'truetype', ext: '.ttf' },
               { type: 'svg', ext: '.svg' }


### PR DESCRIPTION
For a more bulletproof syntax, woff2 is necessary, it is faster and has a smaller footprint