### PR TITLE
Upgrade dev deps and fix tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ gulp.task('lint', function () {
 });
 
 gulp.task('test', function () {
-  return gulp.src('test/*.js', { read: false }).pipe(mocha({reporter: 'nyan'}));
+  return gulp.src('test/*.js', { read: false }).pipe(mocha());
 });
 
 gulp.task('watch', function() {

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "postcss": "^5.0.0"
   },
   "devDependencies": {
-    "gulp-eslint": "^0.12.0",
-    "gulp-mocha": "^2.0.1",
     "chai": "^2.3.0",
-    "gulp": "^3.8.11"
+    "gulp": "^3.8.11",
+    "gulp-eslint": "^0.12.0",
+    "gulp-mocha": "^4.3.1"
   },
   "scripts": {
     "test": "gulp check"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "postcss": "^5.0.0"
   },
   "devDependencies": {
-    "chai": "^2.3.0",
+    "chai": "^4.1.0",
     "gulp": "^3.8.11",
     "gulp-eslint": "^0.12.0",
     "gulp-mocha": "^4.3.1"

--- a/test/fixtures/test.expected.css
+++ b/test/fixtures/test.expected.css
@@ -2,6 +2,7 @@
   font-family: 'Test';
   src: url("/path/to/font/test.eot");
   src: url("/path/to/font/test.eot?#iefix") format('embedded-opentype'),
+       url("/path/to/font/test.woff2") format('woff2'),
        url("/path/to/font/test.woff") format('woff'),
        url("/path/to/font/test.ttf") format('truetype'),
        url("/path/to/font/test.svg") format('svg');

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--reporter nyan

--- a/test/test.js
+++ b/test/test.js
@@ -8,14 +8,14 @@ var postcss = require('postcss'),
     plugin = require('../');
 
 var test = function (fixture, opts, done) {
-  var input = fixture + '.css',
-      expected = fixture + '.expected.css';
+  var from = path.join(__dirname, 'fixtures', fixture + '.css'),
+      to = path.join(__dirname, 'fixtures', fixture + '.expected.css');
 
-  input = fs.readFileSync(path.join(__dirname, 'fixtures', input), 'utf8');
-  expected = fs.readFileSync(path.join(__dirname, 'fixtures', expected), 'utf8');
+  var input = fs.readFileSync(from, 'utf8'),
+      expected = fs.readFileSync(to, 'utf8');
 
   postcss([ plugin(opts) ])
-    .process(input)
+    .process(input, { from: from })
     .then(function (result) {
       expect(result.css).to.eql(expected);
       done(null, result);
@@ -38,7 +38,7 @@ describe('postcss-fontpath', function () {
   it('warns when file in font-path not exists', function (done) {
     test('missing', { checkPath: true }, function (error, result) {
       expect(error).to.be.null;
-      expect(result.warnings()).to.have.lengthOf(4);
+      expect(result.warnings()).to.have.lengthOf(5);
       done();
     });
   });


### PR DESCRIPTION
Since #9 already upgrades to PostCSS v6, here I focused on fixing failing tests and upgrading dev deps. The only thing left to upgrade would be eslint to v4.